### PR TITLE
feat: add GNOME 49 (Brescia) to supported shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "hara-hachi-bu@ZviBaratz",
     "name": "Hara Hachi Bu",
     "description": "Control power profiles and battery charging limits from Quick Settings. Set charge thresholds to extend battery lifespan, create profiles for different scenarios (docked, travel), and let them switch automatically based on conditions and schedules. Supports ThinkPad, Framework, ASUS, and other laptops with kernel-level battery control. Uses polkit (pkexec) for privileged battery threshold writes. Uses clipboard to copy install command. Accesses private QuickSettingsMenu API for indicator management.",
-    "shell-version": ["46", "47", "48"],
+    "shell-version": ["46", "47", "48", "49"],
     "settings-schema": "org.gnome.shell.extensions.hara-hachi-bu",
     "gettext-domain": "hara-hachi-bu",
     "url": "https://github.com/ZviBaratz/hara-hachi-bu"


### PR DESCRIPTION
## Summary

Adds GNOME 49 to the `shell-version` list in `metadata.json`.

## Analysis (agent-audited 2026-03-16)

| Risk Area | GNOME 49 Status |
|-----------|----------------|
| Extension loads | ✅ No API removals affecting this extension |
| Indicator hide/show | ✅ Identity-based detection (not index-based) |
| Indicator reorder | ⚠️ Possible 1-position offset on first run — benign, self-correcting |
| Quick Settings layout | ✅ `St.BoxLayout.vertical` deprecated but functional until GNOME 50 |
| D-Bus / Power Profiles | ✅ Correct bus name (`org.freedesktop.UPower.PowerProfiles`) |

## Test Plan

Run on Fedora 43 or GNOME OS Nightly:
- [ ] Extension loads cleanly (no journalctl errors)
- [ ] Quick Settings tile renders correctly
- [ ] Hide/show power profile indicator works
- [ ] Reorder position is approximately correct

## Notes

- `St.BoxLayout { vertical: true }` needs fixing before GNOME 50 (tracked separately)
- No code changes beyond `metadata.json`