### PR TITLE
feat: add GNOME 49/50 support with backward-compatible orientation fix

### DIFF
--- a/lib/quickSettingsPanel.js
+++ b/lib/quickSettingsPanel.js
@@ -97,7 +97,7 @@ const PowerManagerToggle = GObject.registerClass(
                 vscrollbar_policy: St.PolicyType.AUTOMATIC,
             });
 
-            this._scrollBox = new St.BoxLayout({vertical: true});
+            this._scrollBox = new St.BoxLayout({orientation: Clutter.Orientation.VERTICAL});
             scrollView.set_child(this._scrollBox);
 
             // Add content to the scroll box
@@ -906,7 +906,7 @@ const PowerManagerToggle = GObject.registerClass(
 
             // Replace single label with a two-line vertical layout (title + subtitle)
             const labelBox = new St.BoxLayout({
-                vertical: true,
+                orientation: Clutter.Orientation.VERTICAL,
                 y_align: Clutter.ActorAlign.CENTER,
                 x_expand: true,
             });

--- a/lib/quickSettingsPanel.js
+++ b/lib/quickSettingsPanel.js
@@ -12,6 +12,7 @@ import GObject from 'gi://GObject';
 import Pango from 'gi://Pango';
 import St from 'gi://St';
 import Gettext from 'gettext';
+import {Config} from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
@@ -21,6 +22,8 @@ import * as ScheduleUtils from './scheduleUtils.js';
 import {getIconFromPath} from './helper.js';
 
 const _ = (s) => Gettext.dgettext('hara-hachi-bu', s);
+
+const shellMajor = parseInt(Config.PACKAGE_VERSION.split('.')[0]);
 
 const {BATTERY_MODES, POWER_MODES, isAutoManaged, getProfileDisplayName, getProfileIcon} = ProfileMatcher;
 
@@ -97,7 +100,11 @@ const PowerManagerToggle = GObject.registerClass(
                 vscrollbar_policy: St.PolicyType.AUTOMATIC,
             });
 
-            this._scrollBox = new St.BoxLayout({orientation: Clutter.Orientation.VERTICAL});
+            this._scrollBox = new St.BoxLayout(
+                shellMajor >= 48
+                    ? {orientation: Clutter.Orientation.VERTICAL}
+                    : {vertical: true}
+            );
             scrollView.set_child(this._scrollBox);
 
             // Add content to the scroll box
@@ -905,11 +912,11 @@ const PowerManagerToggle = GObject.registerClass(
             this._boostChargeItem.setOrnament(PopupMenu.Ornament.HIDDEN);
 
             // Replace single label with a two-line vertical layout (title + subtitle)
-            const labelBox = new St.BoxLayout({
-                orientation: Clutter.Orientation.VERTICAL,
-                y_align: Clutter.ActorAlign.CENTER,
-                x_expand: true,
-            });
+            const labelBox = new St.BoxLayout(
+                shellMajor >= 48
+                    ? {orientation: Clutter.Orientation.VERTICAL, y_align: Clutter.ActorAlign.CENTER, x_expand: true}
+                    : {vertical: true, y_align: Clutter.ActorAlign.CENTER, x_expand: true}
+            );
             this._boostChargeTitleLabel = new St.Label({text: _('Boost Charge')});
             this._boostChargeSubtitle = new St.Label({
                 text: _('Temporarily charge to 100%'),

--- a/lib/quickSettingsPanel.js
+++ b/lib/quickSettingsPanel.js
@@ -12,7 +12,7 @@ import GObject from 'gi://GObject';
 import Pango from 'gi://Pango';
 import St from 'gi://St';
 import Gettext from 'gettext';
-import {Config} from 'resource:///org/gnome/shell/misc/config.js';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "hara-hachi-bu@ZviBaratz",
     "name": "Hara Hachi Bu",
     "description": "Control power profiles and battery charging limits from Quick Settings. Set charge thresholds to extend battery lifespan, create profiles for different scenarios (docked, travel), and let them switch automatically based on conditions and schedules. Supports ThinkPad, Framework, ASUS, and other laptops with kernel-level battery control. Uses polkit (pkexec) for privileged battery threshold writes. Uses clipboard to copy install command. Accesses private QuickSettingsMenu API for indicator management.",
-    "shell-version": ["46", "47", "48"],
+    "shell-version": ["48", "49", "50"],
     "settings-schema": "org.gnome.shell.extensions.hara-hachi-bu",
     "gettext-domain": "hara-hachi-bu",
     "url": "https://github.com/ZviBaratz/hara-hachi-bu"

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
     "uuid": "hara-hachi-bu@ZviBaratz",
     "name": "Hara Hachi Bu",
     "description": "Control power profiles and battery charging limits from Quick Settings. Set charge thresholds to extend battery lifespan, create profiles for different scenarios (docked, travel), and let them switch automatically based on conditions and schedules. Supports ThinkPad, Framework, ASUS, and other laptops with kernel-level battery control. Uses polkit (pkexec) for privileged battery threshold writes. Uses clipboard to copy install command. Accesses private QuickSettingsMenu API for indicator management.",
-    "shell-version": ["48", "49", "50"],
+    "shell-version": ["46", "47", "48", "49", "50"],
     "settings-schema": "org.gnome.shell.extensions.hara-hachi-bu",
     "gettext-domain": "hara-hachi-bu",
     "url": "https://github.com/ZviBaratz/hara-hachi-bu"


### PR DESCRIPTION
## Summary

- Adds GNOME 49 and 50 to `shell-version` in `metadata.json`
- Fixes `St.BoxLayout` orientation for GNOME 48+ while preserving backward compatibility with GNOME 46/47
- Uses runtime version detection (`Config.PACKAGE_VERSION`) to select between `vertical: true` (GNOME 46-47) and `orientation: Clutter.Orientation.VERTICAL` (GNOME 48+)

## Supported versions

`["46", "47", "48", "49", "50"]`

## Test plan

- [ ] Install on GNOME 46 (Ubuntu 24.04 LTS) — verify Quick Settings panel renders correctly
- [ ] Verify scroll box and boost charge label box use correct orientation property per version
- [ ] Confirm extension loads without errors in GNOME Shell logs (`journalctl -f /usr/bin/gnome-shell`)