### PR TITLE
ci: upgrade actions to Node.js 24 before 2026-06-02 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     validate:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+            - uses: actions/checkout@v6
 
             - name: Install dependencies
               run: |
@@ -44,7 +44,7 @@ jobs:
                   fi
 
             - name: Upload build artifact
-              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+              uses: actions/upload-artifact@v6
               with:
                   name: hara-hachi-bu-${{ github.sha }}
                   path: hara-hachi-bu@ZviBaratz.zip

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,10 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: 3.x
             - run: pip install mkdocs-material mkdocs-minify-plugin


### PR DESCRIPTION
## Summary

- `actions/checkout`: v4 → v6 (node20 → node24) in `ci.yml` and `docs.yml`
- `actions/upload-artifact`: v4 → v6 (node20 → node24) in `ci.yml`
- `actions/setup-python`: v5 → v6 (node20 → node24) in `docs.yml`

GitHub Actions [deprecated Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) — hard cutover on **2026-06-02**.

Note: `softprops/action-gh-release@v2` in `release.yml` is a third-party action that hasn't yet released a Node.js 24 version; left unchanged.