### PR TITLE
fix: gate verbose logging behind DEBUG flag (EGO-A-004)

### DIFF
--- a/lib/batteryThresholdController.js
+++ b/lib/batteryThresholdController.js
@@ -11,7 +11,7 @@ import * as Helper from './helper.js';
 import * as Constants from './constants.js';
 import {DeviceManager} from './device/DeviceManager.js';
 
-const {readFileAsync, readFileIntAsync} = Helper;
+const {readFileAsync, readFileIntAsync, debugError, debugWarn} = Helper;
 
 const AUTO_DISCHARGE_HYSTERESIS = 1; // % buffer to prevent rapid toggling
 const AUTO_DISCHARGE_STOP_MARGIN = 5; // % below end threshold to stop on end-only devices
@@ -78,7 +78,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     (dev, start, end) => {
                         this.emit('threshold-changed', start, end);
                         this._updateAutoDischarge().catch((e) => {
-                            if (!this._destroyed) console.error(`Hara Hachi Bu: Auto-discharge error: ${e.message}`);
+                            if (!this._destroyed) debugError(`Auto-discharge error: ${e.message}`);
                         });
                     },
                     'force-discharge-changed',
@@ -86,7 +86,7 @@ export const BatteryThresholdController = GObject.registerClass(
                         // Refresh sysfs status since file monitor may not fire on sysfs
                         this._updateSysfsStatus().catch((e) => {
                             if (!this._destroyed)
-                                console.error(`Hara Hachi Bu: sysfs status update error: ${e.message}`);
+                                debugError(`sysfs status update error: ${e.message}`);
                         });
                         this.emit('force-discharge-changed', enabled);
                         // Update state if external change happened
@@ -205,7 +205,7 @@ export const BatteryThresholdController = GObject.registerClass(
                                         this.emit('power-source-changed', this._onBattery);
                                         this._updateAutoDischarge().catch((e) => {
                                             if (!this._destroyed)
-                                                console.error(`Hara Hachi Bu: Auto-discharge error: ${e.message}`);
+                                                debugError(`Auto-discharge error: ${e.message}`);
                                         });
                                     }
                                 },
@@ -247,7 +247,7 @@ export const BatteryThresholdController = GObject.registerClass(
                                             statusChanged = true;
                                             this._updateAutoDischarge().catch((e) => {
                                                 if (!this._destroyed)
-                                                    console.error(`Hara Hachi Bu: Auto-discharge error: ${e.message}`);
+                                                    debugError(`Auto-discharge error: ${e.message}`);
                                             });
                                         }
                                     }
@@ -260,8 +260,8 @@ export const BatteryThresholdController = GObject.registerClass(
                                             // Sync sysfs cache since file monitor may not fire on sysfs
                                             this._updateSysfsStatus().catch((e) => {
                                                 if (!this._destroyed) {
-                                                    console.error(
-                                                        `Hara Hachi Bu: sysfs status update error: ${e.message}`
+                                                    debugError(
+                                                        `sysfs status update error: ${e.message}`
                                                     );
                                                 }
                                             });
@@ -283,7 +283,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     this._proxyInitTimeout = null;
                     if (this._destroyed) return GLib.SOURCE_REMOVE;
                     if (!upowerReady || !displayDeviceReady) {
-                        console.warn('Hara Hachi Bu: UPower proxy initialization timed out');
+                        debugWarn('UPower proxy initialization timed out');
                         upowerReady = true;
                         displayDeviceReady = true;
                         checkReady();
@@ -308,14 +308,14 @@ export const BatteryThresholdController = GObject.registerClass(
                         if (eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
                             this._updateSysfsStatus().catch((e) => {
                                 if (!this._destroyed)
-                                    console.error(`Hara Hachi Bu: Status monitor callback error: ${e.message}`);
+                                    debugError(`Status monitor callback error: ${e.message}`);
                             });
                         }
                     },
                     this
                 );
             } catch (e) {
-                console.error(`Hara Hachi Bu: Failed to initialize status monitor: ${e.message}`);
+                debugError(`Failed to initialize status monitor: ${e.message}`);
             }
         }
 
@@ -328,7 +328,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     this.emit('battery-status-changed');
                 }
             } catch (e) {
-                if (!this._destroyed) console.error(`Hara Hachi Bu: Error reading status: ${e.message}`);
+                if (!this._destroyed) debugError(`Error reading status: ${e.message}`);
             }
         }
 
@@ -463,7 +463,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     if (this.forceDischargeEnabled) {
                         const success = await this.setForceDischarge(false, false);
                         if (!success && !this._destroyed)
-                            console.warn('Hara Hachi Bu: Auto-discharge disable failed on battery');
+                            debugWarn('Auto-discharge disable failed on battery');
 
                         this._autoManagementActive = false;
                     }
@@ -485,7 +485,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     if (success) {
                         this._autoManagementActive = true;
                     } else if (!this._destroyed) {
-                        console.warn(`Hara Hachi Bu: Auto-discharge enable failed at ${batteryLevel}%`);
+                        debugWarn(`Auto-discharge enable failed at ${batteryLevel}%`);
                     }
                 } else if (batteryLevel <= effectiveStopThreshold && this.forceDischargeEnabled) {
                     // 3. Stop Condition: At or Below Effective Stop Threshold
@@ -493,7 +493,7 @@ export const BatteryThresholdController = GObject.registerClass(
                     if (success) {
                         this._autoManagementActive = false;
                     } else if (!this._destroyed) {
-                        console.warn(`Hara Hachi Bu: Auto-discharge disable failed at ${batteryLevel}%`);
+                        debugWarn(`Auto-discharge disable failed at ${batteryLevel}%`);
                     }
                 }
             } finally {
@@ -501,7 +501,7 @@ export const BatteryThresholdController = GObject.registerClass(
                 if (this._pendingAutoDischargeUpdate && !this._destroyed) {
                     this._pendingAutoDischargeUpdate = false;
                     this._updateAutoDischarge().catch((e) => {
-                        if (!this._destroyed) console.error(`Hara Hachi Bu: Auto-discharge error: ${e.message}`);
+                        if (!this._destroyed) debugError(`Auto-discharge error: ${e.message}`);
                     });
                 }
             }

--- a/lib/device/GenericSysfsDevice.js
+++ b/lib/device/GenericSysfsDevice.js
@@ -273,7 +273,7 @@ export const GenericSysfsDevice = GObject.registerClass(
 
             // Validate thresholds (battery name already validated in constructor)
             if (!validateThreshold(start) || !validateThreshold(end)) {
-                console.error(`Hara Hachi Bu: Invalid threshold values: start=${start}, end=${end}`);
+                debugError(`Invalid threshold values: start=${start}, end=${end}`);
                 return false;
             }
 
@@ -320,7 +320,7 @@ export const GenericSysfsDevice = GObject.registerClass(
                 } else if (status === exitCode.COMMAND_NOT_FOUND) {
                     console.error(`Hara Hachi Bu: Helper script not found at ${this.ctlPath}. Run install-helper.sh`);
                 } else if (stderr) {
-                    console.error(`Hara Hachi Bu: Failed to set thresholds: ${stderr.trim()}`);
+                    debugError(`Failed to set thresholds: ${stderr.trim()}`);
                 }
 
                 return false;
@@ -379,7 +379,7 @@ export const GenericSysfsDevice = GObject.registerClass(
                 const mode = enabled ? 'force-discharge' : 'auto';
 
                 if (!validateForceDischargeMode(mode)) {
-                    console.error(`Hara Hachi Bu: Invalid force discharge mode '${mode}'`);
+                    debugError(`Invalid force discharge mode '${mode}'`);
                     return false;
                 }
 
@@ -430,8 +430,8 @@ export const GenericSysfsDevice = GObject.registerClass(
                         }
                     }
 
-                    console.warn(
-                        'Hara Hachi Bu: Force discharge write succeeded but verification failed. Reverting state.'
+                    debugWarn(
+                        'Force discharge write succeeded but verification failed. Reverting state.'
                     );
                     await this.refreshValues(); // Re-read actual state from disk
                     this.emit('force-discharge-changed', this._forceDischargeEnabled);
@@ -443,7 +443,7 @@ export const GenericSysfsDevice = GObject.registerClass(
                 } else if (status === exitCode.COMMAND_NOT_FOUND) {
                     console.error(`Hara Hachi Bu: Helper script not found at ${this.ctlPath}. Run install-helper.sh`);
                 } else if (stderr) {
-                    console.error(`Hara Hachi Bu: Failed to set force discharge: ${stderr.trim()}`);
+                    debugError(`Failed to set force discharge: ${stderr.trim()}`);
                 }
 
                 return false;

--- a/lib/device/GenericSysfsDevice.js
+++ b/lib/device/GenericSysfsDevice.js
@@ -23,6 +23,8 @@ const {
     validateThreshold,
     validateForceDischargeMode,
     isForceDischargeActive,
+    debugError,
+    debugWarn,
 } = Helper;
 
 // Exponential backoff delays (ms) for verifying force discharge state after write (~3.15s total)
@@ -118,8 +120,8 @@ export const GenericSysfsDevice = GObject.registerClass(
                 this.ctlPath = `/usr/local/bin/${Constants.HELPER_BIN_NAME}`;
 
             if (!this.ctlPath) {
-                console.warn(
-                    `Hara Hachi Bu: ${Constants.HELPER_BIN_NAME} helper not found, battery control will be read-only`
+                debugWarn(
+                    `${Constants.HELPER_BIN_NAME} helper not found, battery control will be read-only`
                 );
                 this._missingHelper = true;
             } else {
@@ -160,7 +162,7 @@ export const GenericSysfsDevice = GObject.registerClass(
 
                     this._connectMonitorSignal();
                 } catch (e) {
-                    console.error(`Hara Hachi Bu: Failed to initialize threshold monitor: ${e.message}`);
+                    debugError(`Failed to initialize threshold monitor: ${e.message}`);
                 }
             }
 
@@ -172,7 +174,7 @@ export const GenericSysfsDevice = GObject.registerClass(
 
                     this._connectForceDischargeMonitor();
                 } catch (e) {
-                    console.error(`Hara Hachi Bu: Failed to initialize force discharge monitor: ${e.message}`);
+                    debugError(`Failed to initialize force discharge monitor: ${e.message}`);
                 }
             }
         }
@@ -211,7 +213,7 @@ export const GenericSysfsDevice = GObject.registerClass(
                     this.emit('threshold-changed', this.startLimitValue, this.endLimitValue);
                 }
             } catch (e) {
-                if (!this._destroyed) console.error(`Hara Hachi Bu: File monitor error: ${e.message}`);
+                if (!this._destroyed) debugError(`File monitor error: ${e.message}`);
             }
         }
 
@@ -228,7 +230,7 @@ export const GenericSysfsDevice = GObject.registerClass(
                     if (eventType === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
                         this._checkForceDischargeState().catch((e) => {
                             if (!this._destroyed)
-                                console.error(`Hara Hachi Bu: Force discharge monitor error: ${e.message}`);
+                                debugError(`Force discharge monitor error: ${e.message}`);
                         });
                     }
                 },

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -276,3 +276,19 @@ export function getIconFromPath(iconFolder, iconName) {
     if (file.query_exists(null)) return Gio.icon_new_for_string(localPath);
     return Gio.ThemedIcon.new(iconName);
 }
+
+// Flip to true locally to surface diagnostic logs. Shipped as false so the
+// extension stays quiet in production per the EGO review guidelines.
+export const DEBUG = false;
+
+export function debugLog(...args) {
+    if (DEBUG) console.log('Hara Hachi Bu:', ...args);
+}
+
+export function debugWarn(...args) {
+    if (DEBUG) console.warn('Hara Hachi Bu:', ...args);
+}
+
+export function debugError(...args) {
+    if (DEBUG) console.error('Hara Hachi Bu:', ...args);
+}

--- a/lib/profileMatcher.js
+++ b/lib/profileMatcher.js
@@ -9,6 +9,7 @@ import Gettext from 'gettext';
 import * as RuleEvaluator from './ruleEvaluator.js';
 import * as ScheduleUtils from './scheduleUtils.js';
 import * as Constants from './constants.js';
+import {debugWarn} from './helper.js';
 
 const _ = (s) => Gettext.dgettext('hara-hachi-bu', s);
 
@@ -156,8 +157,8 @@ export function getThresholdsForMode(batteryMode, settings = null) {
         const start = settings.get_int(config.startKey);
         const end = settings.get_int(config.endKey);
         if (start >= end) {
-            console.warn(
-                `Hara Hachi Bu: Invalid thresholds for ${batteryMode} (start=${start} >= end=${end}), using defaults`
+            debugWarn(
+                `Invalid thresholds for ${batteryMode} (start=${start} >= end=${end}), using defaults`
             );
             return {start: config.defaultStart, end: config.defaultEnd};
         }
@@ -210,8 +211,8 @@ export function validateProfile(profile) {
             const validRules = profile.rules.filter((rule, i) => {
                 const result = RuleEvaluator.validateCondition(rule);
                 if (!result.valid) {
-                    console.warn(
-                        `Hara Hachi Bu: Dropping invalid rule ${i + 1} from profile "${profile.id}": ${result.error}`
+                    debugWarn(
+                        `Dropping invalid rule ${i + 1} from profile "${profile.id}": ${result.error}`
                     );
                     return false;
                 }
@@ -227,8 +228,8 @@ export function validateProfile(profile) {
         if (profile.schedule.enabled) {
             const scheduleResult = ScheduleUtils.validateSchedule(profile.schedule);
             if (!scheduleResult.valid) {
-                console.warn(
-                    `Hara Hachi Bu: Invalid schedule in profile "${profile.id}": ${scheduleResult.error}, setting to null`
+                debugWarn(
+                    `Invalid schedule in profile "${profile.id}": ${scheduleResult.error}, setting to null`
                 );
                 profile.schedule = null;
             }
@@ -280,8 +281,8 @@ export function getCustomProfiles(settings) {
 
         const validProfiles = profiles.filter((p) => {
             if (validateProfile(p) === null) {
-                console.warn(
-                    `Hara Hachi Bu: Dropping invalid profile (id: ${p?.id || 'unknown'}, name: ${p?.name || 'unknown'}): missing or invalid required fields`
+                debugWarn(
+                    `Dropping invalid profile (id: ${p?.id || 'unknown'}, name: ${p?.name || 'unknown'}): missing or invalid required fields`
                 );
                 return false;
             }
@@ -371,10 +372,7 @@ export function createProfile(settings, id, name, powerMode, batteryMode, rules 
         schedule: schedule || null,
     };
 
-    if (validateProfile(newProfile) === null) {
-        console.warn(`Hara Hachi Bu: createProfile validation failed for "${id}"`);
-        return false;
-    }
+    if (validateProfile(newProfile) === null) return false;
 
     profiles.push(newProfile);
     saveCustomProfiles(settings, profiles);
@@ -410,10 +408,7 @@ export function updateProfile(settings, profileId, updates) {
     }
 
     const merged = {...profiles[index], ...updates};
-    if (validateProfile(merged) === null) {
-        console.warn(`Hara Hachi Bu: updateProfile validation failed for "${profileId}"`);
-        return false;
-    }
+    if (validateProfile(merged) === null) return false;
     profiles[index] = merged;
     saveCustomProfiles(settings, profiles);
     return true;

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -22,6 +22,7 @@ import * as ProfileMatcher from './profileMatcher.js';
 import {ParameterDetector} from './parameterDetector.js';
 import * as RuleEvaluator from './ruleEvaluator.js';
 import * as ScheduleUtils from './scheduleUtils.js';
+import {debugError, debugWarn} from './helper.js';
 
 // Standard GJS pattern: promisify D-Bus proxy creation for async/await
 Gio._promisify(Gio.DBusProxy, 'new_for_bus');
@@ -276,7 +277,7 @@ export const StateManager = GObject.registerClass(
                         if (enabled) {
                             this._batteryController.checkAutoManagement().catch((e) => {
                                 if (!this._destroyed)
-                                    console.error(`Hara Hachi Bu: Auto-management check error: ${e.message}`);
+                                    debugError(`Auto-management check error: ${e.message}`);
                             });
                         } else {
                             this._batteryController.cancelAutoManagement();
@@ -289,7 +290,7 @@ export const StateManager = GObject.registerClass(
                     if (this._settings.get_boolean('auto-switch-enabled')) {
                         this._setAutoManagePaused(false);
                         this._evaluateAndApplyRules().catch((e) => {
-                            if (!this._destroyed) console.error(`Hara Hachi Bu: Error evaluating rules: ${e.message}`);
+                            if (!this._destroyed) debugError(`Error evaluating rules: ${e.message}`);
                         });
                     }
                     this._rescheduleTimer();
@@ -318,7 +319,7 @@ export const StateManager = GObject.registerClass(
                     () => {
                         this._initialRuleEvalTimeout = null;
                         this._evaluateAndApplyRules().catch((e) => {
-                            if (!this._destroyed) console.error(`Hara Hachi Bu: Error evaluating rules: ${e.message}`);
+                            if (!this._destroyed) debugError(`Error evaluating rules: ${e.message}`);
                         });
                         return GLib.SOURCE_REMOVE;
                     }
@@ -378,7 +379,7 @@ export const StateManager = GObject.registerClass(
             this._ruleEvaluationTimeout = GLib.timeout_add(GLib.PRIORITY_DEFAULT, RULE_EVAL_DEBOUNCE_MS, () => {
                 this._ruleEvaluationTimeout = null;
                 this._evaluateAndApplyRules().catch((e) => {
-                    if (!this._destroyed) console.error(`Hara Hachi Bu: Error evaluating rules: ${e.message}`);
+                    if (!this._destroyed) debugError(`Error evaluating rules: ${e.message}`);
                 });
                 return GLib.SOURCE_REMOVE;
             });
@@ -495,7 +496,7 @@ export const StateManager = GObject.registerClass(
         resumeAutoManage() {
             this._setAutoManagePaused(false);
             this._evaluateAndApplyRules().catch((e) => {
-                if (!this._destroyed) console.error('Hara Hachi Bu: Error evaluating rules on resume:', e);
+                if (!this._destroyed) debugError('Error evaluating rules on resume:', e);
             });
         }
 
@@ -708,8 +709,8 @@ export const StateManager = GObject.registerClass(
                         this.setPowerMode(config.powerMode, false)
                             .then((res) => {
                                 if (!res) {
-                                    console.warn(
-                                        `Hara Hachi Bu: Failed to set power mode to '${config.powerMode}' for profile '${profileName}'`
+                                    debugWarn(
+                                        `Failed to set power mode to '${config.powerMode}' for profile '${profileName}'`
                                     );
                                 }
                                 return res;
@@ -728,8 +729,8 @@ export const StateManager = GObject.registerClass(
                         this.setBatteryMode(config.batteryMode, false)
                             .then((res) => {
                                 if (!res) {
-                                    console.warn(
-                                        `Hara Hachi Bu: Failed to set battery mode to '${config.batteryMode}' for profile '${profileName}'`
+                                    debugWarn(
+                                        `Failed to set battery mode to '${config.batteryMode}' for profile '${profileName}'`
                                     );
                                 }
                                 return res;
@@ -751,7 +752,7 @@ export const StateManager = GObject.registerClass(
 
             // No controllers available — nothing to apply
             if (labels.length === 0) {
-                console.warn(`Hara Hachi Bu: No controllers available to apply profile '${profileName}'`);
+                debugWarn(`No controllers available to apply profile '${profileName}'`);
                 return false;
             }
 
@@ -874,7 +875,7 @@ export const StateManager = GObject.registerClass(
                         this._evaluateAndApplyRulesForSchedule();
                     } catch (e) {
                         if (!this._destroyed)
-                            console.error(`Hara Hachi Bu: Error on schedule evaluation: ${e.message}`);
+                            debugError(`Error on schedule evaluation: ${e.message}`);
                     }
                 }
                 return GLib.SOURCE_REMOVE;
@@ -911,7 +912,7 @@ export const StateManager = GObject.registerClass(
                                     this._evaluateAndApplyRulesForSchedule();
                                 } catch (e) {
                                     if (!this._destroyed)
-                                        console.error(`Hara Hachi Bu: Error on post-resume evaluation: ${e.message}`);
+                                        debugError(`Error on post-resume evaluation: ${e.message}`);
                                 }
                             }
                         }
@@ -967,7 +968,7 @@ export const StateManager = GObject.registerClass(
                 if (!this._destroyed && this._boostChargeActive) {
                     this._deactivateBoostCharge('timeout').catch((e) => {
                         if (!this._destroyed)
-                            console.error(`Hara Hachi Bu: Error on boost charge timeout: ${e.message}`);
+                            debugError(`Error on boost charge timeout: ${e.message}`);
                     });
                 }
                 return GLib.SOURCE_REMOVE;

--- a/lib/stateManager.js
+++ b/lib/stateManager.js
@@ -226,7 +226,7 @@ export const StateManager = GObject.registerClass(
                             if (level >= 99 || status === 'Full' || (status === 'Not charging' && level >= 95)) {
                                 this._deactivateBoostCharge('battery_full').catch((e) => {
                                     if (!this._destroyed)
-                                        console.error(`Hara Hachi Bu: Error deactivating boost charge: ${e.message}`);
+                                        debugError(`Error deactivating boost charge: ${e.message}`);
                                 });
                             }
                         }
@@ -352,7 +352,7 @@ export const StateManager = GObject.registerClass(
             if (this._boostChargeActive && paramName === 'power_source' && paramValue === 'battery') {
                 this._deactivateBoostCharge('ac_disconnected').catch((e) => {
                     if (!this._destroyed)
-                        console.error(`Hara Hachi Bu: Error deactivating boost charge on AC disconnect: ${e.message}`);
+                        debugError(`Error deactivating boost charge on AC disconnect: ${e.message}`);
                 });
             }
 
@@ -685,7 +685,7 @@ export const StateManager = GObject.registerClass(
 
             const config = ProfileMatcher.getProfileById(this._settings, profileName);
             if (!config) {
-                console.warn(`Hara Hachi Bu: Profile '${profileName}' not found in settings`);
+                debugWarn(`Profile '${profileName}' not found in settings`);
                 this._notifyError(_('Scenario Switch Failed'), _('Scenario "%s" does not exist.').format(profileName));
                 return false;
             }
@@ -769,7 +769,7 @@ export const StateManager = GObject.registerClass(
                 }
             } else {
                 const failedParts = labels.filter((label, i) => results[i] !== true);
-                console.warn(`Hara Hachi Bu: Profile '${profileName}' applied with errors`);
+                debugWarn(`Profile '${profileName}' applied with errors`);
                 // Partial failure: state is inconsistent, so clear profile identity
                 this._currentProfile = null;
                 this.emit('profile-changed', 'custom');


### PR DESCRIPTION
## Summary

- Introduces `DEBUG` + `debugLog`/`debugWarn`/`debugError` helpers in `lib/helper.js`.
- Gates 41 internal-diagnostic console calls across `stateManager`, `batteryThresholdController`, `device/GenericSysfsDevice`, and `profileMatcher`.
- Removes 2 unreachable defensive logs in `profileMatcher` (`createProfile`/`updateProfile` final `validateProfile === null` branches — every field is validated earlier in the same function).
- Retains 13 user-actionable error calls unchanged (D-Bus proxy init failures, force-discharge write failures, unexpected exceptions, "run install-helper.sh" prompts, post-boost restore failures).

Flagged by `shexli` rule EGO-A-004; the [GNOME Shell extension review guidelines](https://gjs.guide/extensions/review-guidelines/review-guidelines.html#no-excessive-logging) treat ungated console output as grounds for rejection.

## shexli verification

Before this PR: `shexli` flagged EGO-A-004 on all 4 files with a total of 56 ungated calls.
After this PR: all 4 flagged files clear the rule's threshold of 5.

```
Before:  stateManager 19, batteryThresholdController 16,
         GenericSysfsDevice 14, profileMatcher 7
After:   stateManager  4, batteryThresholdController  3,
         GenericSysfsDevice  4, profileMatcher  1
```

`prefs.js` (7 calls) still trips the rule but was out of scope for #5 — tracked separately in #8.

## Categorization rationale

Each `console.*` call in the four flagged files was triaged:

- **Keep unconditional (A, 13 calls)** — user-visible failure where the log is the best actionable signal. Kept: D-Bus proxy init failures (affect monitoring immediately), unexpected exceptions during profile application, "install helper.sh" prompts that direct the user to the fix, post-boost restore failures.
- **Gate behind `DEBUG` (A-flight → B, 41 calls)** — diagnostic-only. The user-visible notification comes from the higher layer (StateManager `_notifyError`, prefs `Adw.AlertDialog`, Quick Settings subtitle). Example: `GenericSysfsDevice.js` "Invalid threshold values" is an internal precondition check — the caller's write returns false and the user sees the outer "Failed to apply profile" notification.
- **Remove (C, 2 calls)** — defensive log inside an unreachable branch that earlier field-level validation already caught. Caller still receives `false`.

## Design choice: const flag, not a settings toggle

`const DEBUG = false` in `helper.js` rather than a GSettings key. EGO doesn't require a user-facing toggle, and a settings key would add schema-migration surface and a dead UI control. Anyone debugging a regression flips the constant locally, reloads, reproduces.

The helper prepends `'Hara Hachi Bu:'` to every message, so call sites stay terse (`debugError(\`Auto-discharge error: ${e.message}\`)`) and a future rename is a single-line change.

## Out of scope

- `prefs.js` (7 calls flagged by shexli) — tracked in #8. Runs in its own process, minimal runtime impact, but still trips the linter.
- 16 `console.*` calls in other shell-side files (`ruleEvaluator.js`, `parameterDetector.js`, `powerProfileController.js`, `DeviceManager.js`, `CompositeDevice.js`, `quickSettingsPanel.js`, `uiPatcher.js`, `extension.js`) — each is well under the shexli threshold (1–5 per file) and not flagged.
- 4 `console.debug` calls in `MockDevice.js` — mock-only, non-production.

## Test plan

- [x] `node --check` passes on all edited files
- [x] `glib-compile-schemas schemas/` succeeds (sanity run, no schema change)
- [x] `gnome-extensions disable && enable` — extension reaches State: ACTIVE with zero `hara`/`hhb` lines in `journalctl _COMM=gnome-shell` (production-silent with DEBUG=false). Verified twice, once after each commit.
- [x] `uvx shexli /tmp/hhb-clean` — all 4 originally-flagged files clear EGO-A-004 (remaining warnings are all pre-existing and tracked in #6/#8 or in MEMORY.md as reviewer-notes)
- [ ] Flip `DEBUG = true` locally, reload, exercise rule evaluation / file monitors → confirm `Hara Hachi Bu:`-prefixed diagnostic lines reappear
- [ ] Exercise the golden path in Quick Settings (power profile switch, battery mode switch, force-discharge toggle, profile apply, boost charge toggle) → confirm no Category A calls fire unexpectedly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
