### PR TITLE
fix(packaging): exclude install-helper.sh and stop compiling schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,17 @@ A GNOME Shell extension providing unified Quick Settings control for power profi
 ## Installation
 
 ```bash
-# Install from extensions.gnome.org (search "Hara Hachi Bu"), then:
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+# Install from extensions.gnome.org (search "Hara Hachi Bu"), then install
+# the privileged helper so polkit can authorize battery threshold writes:
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
-The helper script enables privileged battery threshold control via polkit. It's a one-time setup.
+This is a one-time setup. The Quick Settings panel will offer to copy this command to your clipboard when it detects the helper is missing.
 
 **Manual installation:**
 

--- a/docs/hardware/troubleshooting.md
+++ b/docs/hardware/troubleshooting.md
@@ -33,8 +33,12 @@ which hhb-power-ctl
 If not found, run the installer:
 
 ```bash
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
 **2. Check polkit rules**
@@ -66,8 +70,12 @@ If no files are shown, your laptop's kernel driver does not expose battery thres
 The helper script is not installed or not in PATH. Install it:
 
 ```bash
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
 If the installer reports a polkit warning, your system may use a non-standard polkit location. Check the install output for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,9 +53,13 @@ Hara Hachi Bu adds a unified section to your GNOME Quick Settings panel where yo
 
 ```bash
 # 1. Install from extensions.gnome.org (search "Hara Hachi Bu")
-# 2. Then install the required helper script:
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+# 2. Then install the privileged helper so polkit can authorize threshold writes:
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
 See [Installation](installation.md) for full details — manual install, polkit setup, and uninstallation.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,30 +26,44 @@ Then log out and log back in (Wayland), or restart GNOME Shell with Alt+F2 → t
 
 ## Helper Script Installation
 
-Battery threshold control requires root privileges. GNOME extensions cannot install system files automatically, so you need to run a one-time setup script.
+Battery threshold control requires root privileges. GNOME extensions cannot install system files automatically, so you need to run a one-time install command.
 
-### Automated (recommended)
+### Recommended one-liner
 
 ```bash
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
-The script copies `hhb-power-ctl` to `/usr/local/bin/` and installs the appropriate polkit rules for your system.
+The Quick Settings panel will offer to copy an equivalent command to your clipboard when it detects the helper is missing.
 
-### Manual
+What each file does:
+
+- `hhb-power-ctl` — the privileged helper invoked via `pkexec` to write battery thresholds.
+- `10-hara-hachi-bu.rules` — polkit rules (≥ 0.106) that let the active local session run the helper without a password prompt.
+- `org.gnome.shell.extensions.hara-hachi-bu.policy` — polkit policy action that maps the helper path to an action ID.
+
+### Step-by-step (equivalent)
 
 ```bash
 # Install the helper script
-sudo cp resources/hhb-power-ctl /usr/local/bin/
-sudo chmod +x /usr/local/bin/hhb-power-ctl
+sudo install -D -m 755 \
+    resources/hhb-power-ctl \
+    /usr/local/bin/hhb-power-ctl
 
-# Install polkit rules (modern polkit >= 0.106)
-sudo cp resources/10-hara-hachi-bu.rules /etc/polkit-1/rules.d/
+# Install polkit rules (polkit >= 0.106)
+sudo install -D -m 644 \
+    resources/10-hara-hachi-bu.rules \
+    /etc/polkit-1/rules.d/10-hara-hachi-bu.rules
 
-# OR for legacy polkit (< 0.106)
-sudo cp resources/org.gnome.shell.extensions.hara-hachi-bu.policy \
-    /usr/share/polkit-1/actions/
+# Install polkit policy action (always required)
+sudo install -D -m 644 \
+    resources/org.gnome.shell.extensions.hara-hachi-bu.policy \
+    /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
 ```
 
 ### Verify Installation
@@ -67,8 +81,7 @@ pkexec hhb-power-ctl BAT0_END_START 60 55
 To remove the helper script and polkit rules:
 
 ```bash
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh --uninstall
+pkexec sh -c 'rm -f /usr/local/bin/hhb-power-ctl /etc/polkit-1/rules.d/10-hara-hachi-bu.rules /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy'
 ```
 
 To remove the extension itself, disable it and delete the directory:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,8 +25,12 @@ Log out and log back in to activate the extension (required on Wayland).
 Battery threshold control requires a privileged helper. Run this once:
 
 ```bash
-cd ~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
-sudo ./install-helper.sh
+EXT_DIR=~/.local/share/gnome-shell/extensions/hara-hachi-bu@ZviBaratz
+pkexec sh -c '
+  install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl &&
+  install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules &&
+  install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy
+' "$EXT_DIR"
 ```
 
 !!! note

--- a/lib/quickSettingsPanel.js
+++ b/lib/quickSettingsPanel.js
@@ -235,7 +235,8 @@ const PowerManagerToggle = GObject.registerClass(
                     'activate',
                     () => {
                         const extDir = this._extensionObject.dir.get_path();
-                        const command = `pkexec "${extDir}/install-helper.sh"`;
+                        const command =
+                            `pkexec sh -c 'install -D -m 755 "$0/resources/hhb-power-ctl" /usr/local/bin/hhb-power-ctl && install -D -m 644 "$0/resources/10-hara-hachi-bu.rules" /etc/polkit-1/rules.d/10-hara-hachi-bu.rules && install -D -m 644 "$0/resources/org.gnome.shell.extensions.hara-hachi-bu.policy" /usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy' "${extDir}"`;
 
                         St.Clipboard.get_default().set_text(St.ClipboardType.CLIPBOARD, command);
 

--- a/package.sh
+++ b/package.sh
@@ -11,12 +11,8 @@ OUTPUT_FILE="${SCRIPT_DIR}/${EXTENSION_UUID}.zip"
 # Remove existing package
 rm -f "$OUTPUT_FILE"
 
-# Compile schemas so manual installs work without glib-compile-schemas
-echo "Compiling schemas..."
-glib-compile-schemas schemas/
-
 # Create zip excluding development files and helper scripts
-# Note: resources/ contains helper scripts that require manual installation
+# Note: resources/ contains helper files that require manual installation
 cd "$SCRIPT_DIR"
 zip -r "$OUTPUT_FILE" \
     extension.js \
@@ -24,7 +20,6 @@ zip -r "$OUTPUT_FILE" \
     metadata.json \
     stylesheet.css \
     LICENSE \
-    install-helper.sh \
     schemas/org.gnome.shell.extensions.hara-hachi-bu.gschema.xml \
     icons/ \
     lib/ \
@@ -37,10 +32,10 @@ zip -r "$OUTPUT_FILE" \
 
 echo "Package created: $OUTPUT_FILE"
 echo ""
-echo "Note: The resources/ directory IS included in the package, but the following files"
-echo "require manual installation to system paths for battery threshold control to work:"
+echo "The resources/ directory is shipped inside the zip. Battery threshold control"
+echo "requires installing these three files to system paths (done by the one-liner"
+echo "the extension copies to your clipboard from the Quick Settings panel, or see"
+echo "README.md):"
 echo "  - resources/hhb-power-ctl -> /usr/local/bin/hhb-power-ctl"
 echo "  - resources/10-hara-hachi-bu.rules -> /etc/polkit-1/rules.d/"
 echo "  - resources/org.gnome.shell.extensions.hara-hachi-bu.policy -> /usr/share/polkit-1/actions/"
-echo ""
-echo "Run 'pkexec ./install-helper.sh' or see README.md for installation instructions."


### PR DESCRIPTION
Closes #6.

## Summary

- Dropped `install-helper.sh` from `package.sh`'s zip allowlist and removed the `glib-compile-schemas schemas/` step — the submission zip no longer ships developer artifacts (shexli EGO-P-006) and no longer leaves a stale `schemas/gschemas.compiled` in the working tree on every pack.
- Replaced the Quick Settings panel's copy-to-clipboard install command (`pkexec "${extDir}/install-helper.sh"`) with a self-contained `pkexec sh -c '…'` one-liner that installs `hhb-power-ctl`, the polkit rules, and the policy file directly from the shipped `resources/` dir. Passing the extension path as `$0` (positional) keeps path interpolation out of the quoted command body, avoiding quoting issues.
- Updated `README.md`, `docs/index.md`, `docs/installation.md` (install + uninstall), `docs/quick-start.md`, and `docs/hardware/troubleshooting.md` (two places) to match. Left `CONTRIBUTING.md`, `docs/contributing.md`, and `CLAUDE.md` alone — they describe the git-clone developer workflow where `install-helper.sh` remains in the repo.

## What's not in this PR

The issue also listed `Makefile`, `.gitignore`, `package-lock.json`, `.editorconfig`, `hara-hachi-bu.pot`, and `eslint.config.mjs` as files to exclude. They're already excluded by `package.sh`'s allowlist approach (the zip only contains files named explicitly in the `zip -r` command), so no action was needed for those.

## Test plan

- [x] `./package.sh` completes; `unzip -l` confirms the zip contains no `install-helper.sh`, no `gschemas.compiled`, and no other dev artifacts (33 files total)
- [x] `sh -c '…' "\$EXT_DIR"` dry-run confirms `$0` resolves to the extension dir and all three source files in `resources/` are readable
- [ ] End-to-end on a fresh unzip: tap the "Setup Required" item in Quick Settings, paste the copied command, confirm `/usr/local/bin/hhb-power-ctl`, `/etc/polkit-1/rules.d/10-hara-hachi-bu.rules`, and `/usr/share/polkit-1/actions/org.gnome.shell.extensions.hara-hachi-bu.policy` all land with the correct modes and threshold control works without password prompts
- [ ] Uninstall one-liner removes all three files cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)