### PR TITLE
fix: surface actionable hint when gschemas.compiled is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Gated 41 internal-diagnostic `console.*` calls behind a `DEBUG` flag in `lib/helper.js` (new `debugLog`/`debugWarn`/`debugError` helpers) across `stateManager`, `batteryThresholdController`, `device/GenericSysfsDevice`, and `profileMatcher`. User-actionable errors (D-Bus init failure, "install helper.sh" prompts, unexpected exceptions) remain unconditional. Removed 2 unreachable defensive logs in `profileMatcher`. Addresses shexli rule EGO-A-004 for shell-side files.
 - Gated 7 defensive `console.error` calls in `prefs.js` catch blocks behind `debugError`, matching the shell-side convention. All sites remain inside catch blocks. Addresses shexli rule EGO-A-004 for prefs-side files.
+- Wrapped `getSettings()` in `extension.js` to log an actionable fix-it hint (`Run "glib-compile-schemas schemas/" (or "make schemas")…`) when `schemas/gschemas.compiled` is missing. The original `GLib.FileError` no longer surfaces as the only signal; the journal now points to the exact recovery command.
 
 ### Packaging
 

--- a/extension.js
+++ b/extension.js
@@ -25,7 +25,17 @@ export default class HaraHachiBuExtension extends Extension {
         if (this._initializing)
             return;
 
-        this._settings = this.getSettings();
+        try {
+            this._settings = this.getSettings();
+        } catch (e) {
+            // getSettings() reads schemas/gschemas.compiled directly; if the
+            // file is missing the extension cannot load. Surface a fix-it
+            // hint instead of the bare GLib.FileError.
+            console.error(
+                'Hara Hachi Bu: Schema not compiled. Run "glib-compile-schemas schemas/" ' +
+                `(or "make schemas") in the extension directory. Original error: ${e}`);
+            throw e;
+        }
         this._powerManager = null;
         this._uiPatcher = null;
 


### PR DESCRIPTION
## Summary

- Wraps `getSettings()` in `extension.js` so a missing/unreadable `schemas/gschemas.compiled` logs a clear `Run "glib-compile-schemas schemas/" (or "make schemas")…` hint via `console.error` before re-throwing.
- The trap arose after #9 dropped the `glib-compile-schemas` step from `package.sh`: if the compiled file is removed (clean, fresh checkout) and gnome-shell restarts before it's regenerated, the extension parks in `ERROR` state and the journal only shows `GLib.FileError: Failed to open file … gschemas.compiled`. The new log points to the exact recovery command.
- Re-throw preserves the shell's existing `ERROR`-state behavior.

## EGO-A-004 budget

`extension.js` now has 3 unconditional `console.error` calls (was 2). Still well under the shexli threshold of 5. The new call is user-actionable (a recovery command), matching the project's `debugError` vs `console.error` convention.

## Test plan

- [x] gjs syntax check of the try/catch pattern passes
- [ ] Manually verified by deleting `schemas/gschemas.compiled`, restarting gnome-shell, and confirming the new hint appears in `journalctl --user -o cat /usr/bin/gnome-shell`

🤖 Generated with [Claude Code](https://claude.com/claude-code)