### PR TITLE
docs: split Unreleased changelog into versioned v1.0.1 and v1.0.2 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.0.2] — 2026-05-11
+
+### Code Quality
+
+- Wrapped `getSettings()` in `extension.js` to log an actionable fix-it hint (`Run "glib-compile-schemas schemas/" (or "make schemas")…`) when `schemas/gschemas.compiled` is missing. The original `GLib.FileError` no longer surfaces as the only signal; the journal now points to the exact recovery command.
+
+## [1.0.1] — 2026-05-07
+
 ### Compatibility
 
 - Added support for GNOME Shell 49 and 50 with version-conditional `St.BoxLayout` orientation handling
@@ -15,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - Gated 41 internal-diagnostic `console.*` calls behind a `DEBUG` flag in `lib/helper.js` (new `debugLog`/`debugWarn`/`debugError` helpers) across `stateManager`, `batteryThresholdController`, `device/GenericSysfsDevice`, and `profileMatcher`. User-actionable errors (D-Bus init failure, "install helper.sh" prompts, unexpected exceptions) remain unconditional. Removed 2 unreachable defensive logs in `profileMatcher`. Addresses shexli rule EGO-A-004 for shell-side files.
 - Gated 7 defensive `console.error` calls in `prefs.js` catch blocks behind `debugError`, matching the shell-side convention. All sites remain inside catch blocks. Addresses shexli rule EGO-A-004 for prefs-side files.
-- Wrapped `getSettings()` in `extension.js` to log an actionable fix-it hint (`Run "glib-compile-schemas schemas/" (or "make schemas")…`) when `schemas/gschemas.compiled` is missing. The original `GLib.FileError` no longer surfaces as the only signal; the journal now points to the exact recovery command.
 
 ### Packaging
 
@@ -121,4 +128,7 @@ First public release of Hara Hachi Bu, a GNOME Shell extension for unified Quick
 - Translated error messages and user-facing strings
 - RTL-safe styling in preferences and Quick Settings UI
 
+[Unreleased]: https://github.com/ZviBaratz/hara-hachi-bu/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/ZviBaratz/hara-hachi-bu/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/ZviBaratz/hara-hachi-bu/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/ZviBaratz/hara-hachi-bu/releases/tag/v1.0.0


### PR DESCRIPTION
## Problem

The CHANGELOG has an \`[Unreleased]\` section covering all post-v1.0.0 work, but v1.0.1 was released on 2026-05-07 and v1.0.2 content (PR #12) landed on 2026-05-11. Neither release has a dated changelog entry.

## Fix

Splits \`[Unreleased]\` into two versioned sections:

**[1.0.1] — 2026-05-07**
- GNOME Shell 49 and 50 support (PR #3)
- Debug flag gating for 48 console calls (PRs #7, #10) — EGO-A-004
- Packaging: removed install-helper.sh from zip, dropped schema compile step (PR #9) — EGO-P-006

**[1.0.2] — 2026-05-11**
- gschemas.compiled missing-hint fix (PR #12)

Also adds Keep a Changelog comparison links at the bottom for all three versions.

## Test plan

- [ ] CHANGELOG renders correctly on GitHub
- [ ] Version comparison links resolve (will work once `v1.0.2` tag is created)

## Next steps

After merging: tag `v1.0.2`, build zip via `make package`, submit to EGO.